### PR TITLE
Bug fixes for argument parsing and automated management of dataset subset length

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -4,6 +4,7 @@ import json
 import cv2
 import random
 import math
+import torch.utils
 import torchvision
 #import tensorflow as tf
 from skimage.transform import resize
@@ -102,11 +103,23 @@ def get_data_loader(dataset_name, batch_size=64, shuffle=False,analyze=False):
             dataset = DataLoader(val_dataset, batch_size=batch_size, shuffle=shuffle,
                                    num_workers=0)
             return dataset
-        train_dataset, test_dataset = torch.utils.data.random_split(val_dataset, [1000, 49000])
+        
+        total_images = len(val_dataset)
+        subset_size = 50000
+        assert subset_size <= total_images, "Subset size is larger than the dataset!"
+        subset_indices = random.sample(range(total_images), subset_size)
+        subset_dataset = torch.utils.data.Subset(val_dataset, subset_indices)
 
-        #just for test
-        test_dataset, _=torch.utils.data.random_split(test_dataset, [1000, 48000])
-        #####
+        N = int(subset_size*0.02)
+        split_sizes = [N, subset_size - N]
+        split_sizes_test = [N, subset_size[1] - N]
+        
+        train_dataset, test_dataset = torch.utils.data.random_split(subset_dataset, split_sizes)
+        #train_dataset, test_dataset = torch.utils.data.random_split(val_dataset, [1000, 49000])
+
+        test_dataset, _=torch.utils.data.random_split(test_dataset, split_sizes_test)
+        #test_dataset, _=torch.utils.data.random_split(test_dataset, [1000, 48000])
+        
 
         train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=shuffle,
                                    num_workers=0)

--- a/train.py
+++ b/train.py
@@ -47,10 +47,10 @@ def main():
                         help='the infinite norm limitation of UAP')
     parser.add_argument('--delta_size', default=224, type=int,
                         help='the size of delta')
-    parser.add_argument('--uap_lr', default=0.1, type=float
+    parser.add_argument('--uap_lr', default=0.1, type=float,
                         help='the leraning rate of UAP')
 
-    parser.add_argument('--prior', default='gauss',choices=['gauss','jigsaw','None'], type='str',
+    parser.add_argument('--prior', default='gauss',choices=['gauss','jigsaw','None'], type=str,
                         help='the range prior of perturbations')
     parser.add_argument('--prior_batch', default=1, type=int,
                         help='the batch size of prior')


### PR DESCRIPTION
 In the `train.py` file, I corrected two issues that were causing execution errors:

- On line 51, I added a missing comma after the type of an argument, which was preventing the code from running correctly.
- On line 53, I replaced neutral quote marks with the correct quotes around the `type=str` parameter, resolving another execution error.

Additionally, I enhanced the `functions.py` file by introducing a new logic that automatically calculates the split sizes for the subset of the dataset being used, based on the provided ratio. This update also allows users to define the size of the subset for the validation dataset, providing more flexibility and control. 

Please review these changes and let me know if you have any questions or concerns.